### PR TITLE
Fix external file change detection in Roslyn LSP

### DIFF
--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -42,13 +42,16 @@ async function executeDefinitions(input: DefinitionsInput, context: ToolContext)
     if (!lspClient.isDocumentOpen(uri)) {
       try {
         const content = readFileSync(absolutePath, 'utf8');
-        await lspClient.openDocument(uri, 'csharp', content);
+        await lspClient.openDocument(uri, 'csharp', content, absolutePath);
         
         // Give LSP time to process the document
         await new Promise(resolve => setTimeout(resolve, 500));
       } catch (error) {
         throw new Error(`Failed to read file: ${absolutePath} - ${error}`);
       }
+    } else {
+      // Document is open, ensure it's fresh
+      await (lspClient as any).ensureDocumentFresh(uri, absolutePath);
     }
 
     // Call LSP definitions

--- a/src/tools/documentSymbols.ts
+++ b/src/tools/documentSymbols.ts
@@ -103,13 +103,16 @@ async function executeDocumentSymbols(input: DocumentSymbolsInput, context: Tool
     if (!lspClient.isDocumentOpen(uri)) {
       try {
         const content = readFileSync(absolutePath, 'utf8');
-        await lspClient.openDocument(uri, 'csharp', content);
+        await lspClient.openDocument(uri, 'csharp', content, absolutePath);
         
         // Give LSP time to process the document
         await new Promise(resolve => setTimeout(resolve, 500));
       } catch (error) {
         throw new Error(`Failed to read file: ${absolutePath} - ${error}`);
       }
+    } else {
+      // Document is open, ensure it's fresh
+      await (lspClient as any).ensureDocumentFresh(uri, absolutePath);
     }
 
     // Call LSP documentSymbols

--- a/src/tools/references.ts
+++ b/src/tools/references.ts
@@ -43,13 +43,16 @@ async function executeReferences(input: ReferencesInput, context: ToolContext): 
     if (!lspClient.isDocumentOpen(uri)) {
       try {
         const content = readFileSync(absolutePath, 'utf8');
-        await lspClient.openDocument(uri, 'csharp', content);
+        await lspClient.openDocument(uri, 'csharp', content, absolutePath);
         
         // Give LSP time to process the document
         await new Promise(resolve => setTimeout(resolve, 500));
       } catch (error) {
         throw new Error(`Failed to read file: ${absolutePath} - ${error}`);
       }
+    } else {
+      // Document is open, ensure it's fresh
+      await (lspClient as any).ensureDocumentFresh(uri, absolutePath);
     }
 
     // Call LSP references


### PR DESCRIPTION
## 🐛 問題

Roslyn LSPセッションが外部ツール（フォーマッター、git操作など）によるファイル変更を検出できない問題を修正しました。

## 🔧 解決策

### 1. ファイル変更時刻の追跡
- `openDocuments` Mapに `lastModified` フィールドを追加
- ファイルを開く際に変更時刻（mtime）を記録

### 2. 外部変更検出メカニズム
- `ensureDocumentFresh()` メソッドを実装
- ツール実行前に必ずファイルの新鮮さをチェック
- 外部変更を検出したら自動的にドキュメントをリフレッシュ

### 3. 安全なリフレッシュ戦略
- `textDocument/didChange` 通知の問題を回避
- close → reopen 方式でドキュメントを更新
- Roslyn LSPサーバーのクラッシュを防止

## 📊 テスト結果

```
✅ SUCCESS: External file changes are properly detected\!
- 初期シンボル数: 2
- 変更後シンボル数: 3 (NewMethodが追加されたことを検出)
- ログ: "File modified externally, refreshing: file://..."
```

## 🎯 影響範囲

- `src/roslyn/lsp-client.ts` - コア変更検出ロジック
- `src/tools/documentSymbols.ts` - ツール更新
- `src/tools/definitions.ts` - ツール更新
- `src/tools/references.ts` - ツール更新

## ✅ テスト手順

1. Roslyn MCPを使用してC#ファイルを分析
2. 外部エディタやコマンドでファイルを変更
3. 再度同じファイルを分析
4. 変更が正しく反映されることを確認

これにより、フォーマッターやgit操作などの外部ツールによる変更が確実に検出され、常に最新のファイル内容でRoslyn LSPが動作するようになります。

🤖 Generated with [Claude Code](https://claude.ai/code)